### PR TITLE
Update dependencies and modernize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ If this tool helps you build better applications, please consider supporting its
 
 Your sponsorship helps maintain and improve this project. Thank you! 🙏
 
-## 🧪 Beta Testing - v0.2.0-beta.0
+## 🚀 Latest Release
 
-**Try the latest beta with Prisma 6 & tRPC 11 support!**
+**Now with full Prisma 6 & tRPC 11 support!**
 
 ```bash
-npm install prisma-trpc-shield-generator@beta
+npm install prisma-trpc-shield-generator
 ```
 
-This beta includes **major upgrades to Prisma 6.12.0+ and tRPC v11.4.3+** - bringing compatibility with the latest versions and their breaking changes. Please test in development and [report any issues](https://github.com/omar-dulaimi/prisma-trpc-shield-generator/issues). Your feedback helps us deliver a stable release!
+This release includes **major upgrades to the latest Prisma 6+ and tRPC v11+** - bringing compatibility with the latest versions and their breaking changes. [Report any issues](https://github.com/omar-dulaimi/prisma-trpc-shield-generator/issues) to help us continue improving!
 
 ## 📖 Table of Contents
 
@@ -283,13 +283,6 @@ export const permissions = shield<Context>({
 - Run `npx prisma generate` after modifying your schema
 - Check that the generator is properly configured in `schema.prisma`
 
-### Supported Prisma Versions
-
-| Prisma Version | Generator Version |
-|----------------|-------------------|
-| 5.x            | Latest            |
-| 4.x            | 0.1.0+            |
-| 2.x - 3.x      | 0.0.x             |
 
 ## 🤝 Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,12 +20,11 @@
       },
       "devDependencies": {
         "@trpc/server": "^11.4.3",
-        "@types/node": "^24.0.15",
-        "@types/prettier": "^2.7.2",
+        "@types/node": "^24.1.0",
         "@vitest/coverage-v8": "^3.2.4",
         "expect-type": "^1.2.2",
         "prisma": "^6.12.0",
-        "trpc-shield": "^1.0.0-beta.2",
+        "trpc-shield": "^1.2.1",
         "typescript": "^5.8.3",
         "vitest": "^3.2.4"
       }
@@ -689,7 +688,7 @@
         "@prisma/get-platform": "6.12.0"
       }
     },
-    "node_modules/@prisma/engines/node_modules/@prisma/engines-version": {
+    "node_modules/@prisma/engines-version": {
       "version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc.tgz",
       "integrity": "sha512-70vhecxBJlRr06VfahDzk9ow4k1HIaSfVUT3X0/kZoHCMl9zbabut4gEXAyzJZxaCGi5igAA7SyyfBI//mmkbQ==",
@@ -705,12 +704,6 @@
         "@prisma/engines-version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
         "@prisma/get-platform": "6.12.0"
       }
-    },
-    "node_modules/@prisma/fetch-engine/node_modules/@prisma/engines-version": {
-      "version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc.tgz",
-      "integrity": "sha512-70vhecxBJlRr06VfahDzk9ow4k1HIaSfVUT3X0/kZoHCMl9zbabut4gEXAyzJZxaCGi5igAA7SyyfBI//mmkbQ==",
-      "license": "Apache-2.0"
     },
     "node_modules/@prisma/generator": {
       "version": "6.12.0",
@@ -1108,21 +1101,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
-      "integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
       }
-    },
-    "node_modules/@types/prettier": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.7.3.tgz",
-      "integrity": "sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "3.2.4",
@@ -1747,6 +1733,15 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.4.tgz",
@@ -2003,15 +1998,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/prompts/node_modules/kleur": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
-      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/rollup": {
@@ -2347,9 +2333,9 @@
       }
     },
     "node_modules/trpc-shield": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/trpc-shield/-/trpc-shield-1.0.0-beta.2.tgz",
-      "integrity": "sha512-ByuL0qhVSOiVTN+WCCl78MFP9pgQ7GyOvVjuj4WVeWP71vBjwWOShkEmGYArg8DPzGx9i0aHmJTM1kMinL0bOA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/trpc-shield/-/trpc-shield-1.2.1.tgz",
+      "integrity": "sha512-SK54zNWkdtNKA51xhCu4n0F9jOQ3PHctQ1FCcVrQFo3r2bUpwUzLwJEfJ4aoH4mafrVOBSyob0CbLppDDcCV8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,12 +40,11 @@
   },
   "devDependencies": {
     "@trpc/server": "^11.4.3",
-    "@types/node": "^24.0.15",
-    "@types/prettier": "^2.7.2",
+    "@types/node": "^24.1.0",
     "@vitest/coverage-v8": "^3.2.4",
     "expect-type": "^1.2.2",
     "prisma": "^6.12.0",
-    "trpc-shield": "^1.0.0-beta.2",
+    "trpc-shield": "^1.2.1",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
   },


### PR DESCRIPTION
## Summary
- Updated dependencies to their latest versions
- Modernized README by removing hardcoded version numbers and beta references
- Removed version compatibility table to reduce maintenance overhead

## Changes
- Updated `@types/node` to v24.1.0
- Updated `trpc-shield` to v1.2.1  
- Removed deprecated `@types/prettier` package
- Updated README sections to use generic version references
- Removed "Supported Prisma Versions" table

## Test plan
- [x] All dependencies updated successfully
- [x] Build and generation commands work correctly
- [x] No breaking changes introduced
- [x] README formatting and links preserved